### PR TITLE
Use vita-rust-bot to create pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     needs: install-vitasdk
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Restore vitasdk cache
         uses: actions/cache/restore@v3
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Restore vitasdk cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: /opt/vitasdk
           key: ${{ runner.os }}-vitasdk
@@ -234,7 +234,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  workflow_dispatch:
 
 env:
   # If you update LLVM_VERSION, remember to also update `update-bindings.yml`
@@ -24,14 +23,6 @@ jobs:
     needs: install-vitasdk
     timeout-minutes: 20
     steps:
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          context: Build example
-          sha: ${{ github.sha }}
-
       - uses: actions/checkout@v3
 
       - name: Restore vitasdk cache
@@ -95,29 +86,12 @@ jobs:
           path: target/armv7-sony-vita-newlibeabihf/release/std-hello-world.*
           if-no-files-found: error
 
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          context: Build example
-          sha: ${{ github.sha }}
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     needs: install-vitasdk
     timeout-minutes: 10
     steps:
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          context: Clippy
-          sha: ${{ github.sha }}
-
       - uses: actions/checkout@v3
 
       - name: Restore vitasdk cache
@@ -140,28 +114,11 @@ jobs:
         run: |
           cargo clippy --tests --workspace -- -Dclippy::all -Dwarnings
 
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          context: Clippy
-          sha: ${{ github.sha }}
-
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          context: Rustfmt
-          sha: ${{ github.sha }}
-
       - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
@@ -175,33 +132,16 @@ jobs:
         run: |
           cargo fmt --check --all
 
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          context: Rustfmt
-          sha: ${{ github.sha }}
-
-
   missing-libs:
     name: Check missing libs
     runs-on: ubuntu-latest
     needs: install-vitasdk
     timeout-minutes: 10
     steps:
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          context: Check missing libs
-          sha: ${{ github.sha }}
-
       - uses: actions/checkout@v3
         with:
           submodules: true
+
       - name: Restore vitasdk cache
         uses: actions/cache/restore@v3
         with:
@@ -236,15 +176,6 @@ jobs:
         run: |
           cargo run --profile build-util -p vitasdk-sys-build-util -- stub-libs --missing-libs --fail-if-any
 
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          context: Check missing libs
-          sha: ${{ github.sha }}
-
   # Checks if there's no diff when regenerating bindings
   check-bindings:
     name: Check bindings
@@ -252,14 +183,6 @@ jobs:
     needs: install-vitasdk
     timeout-minutes: 10
     steps:
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          context: Check bindings
-          sha: ${{ github.sha }}
-
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -304,15 +227,6 @@ jobs:
         run: |
           git add . && git diff --quiet && git diff --cached --quiet
 
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          context: Check bindings
-          sha: ${{ github.sha }}
-
   doc:
     name: Doc
     runs-on: ubuntu-latest
@@ -320,14 +234,6 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          context: Doc
-          sha: ${{ github.sha }}
-
       - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
@@ -339,12 +245,3 @@ jobs:
 
       - name: Run cargo doc
         run: DOCS_RS=1 RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --target armv7-sony-vita-newlibeabihf -Z build-std
-
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          context: Doc
-          sha: ${{ github.sha }}

--- a/.github/workflows/setup-vitasdk.yml
+++ b/.github/workflows/setup-vitasdk.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Cache vitasdk
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ inputs.path }}
           # Don't really know a good key to use here, but the cache will be
@@ -23,7 +23,7 @@ jobs:
           key: ${{ runner.os }}-vitasdk
 
       - name: Checkout VPDM
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vitasdk/vdpm
 

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-vitasdk
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Restore vitasdk cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: /opt/vitasdk
           key: ${{ runner.os }}-vitasdk
@@ -35,7 +35,7 @@ jobs:
 
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ runner.temp }}/llvm
@@ -49,7 +49,7 @@ jobs:
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
       - name: Cache build-util dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -89,7 +89,7 @@ jobs:
 
       - name: Commit and create pull request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
           title: Update vita-headers bindings

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -80,10 +80,18 @@ jobs:
         run: |
           cargo run --profile build-util -p vitasdk-sys-build-util -- bindgen
 
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Commit and create pull request
         id: create-pull-request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           title: Update vita-headers bindings
           body: Created by the action at [.github/workflows/update-bindings.yml](../tree/main/.github/workflows/update-bindings.yml)
           branch: ${{ env.PR_BRANCH }}
@@ -92,10 +100,3 @@ jobs:
           assignees: pheki,ZetaNumbers
           committer: Aphek <bilkow@tutanota.com>
           author: Aphek <bilkow@tutanota.com>
-
-      - name: Trigger build
-        env:
-          # Required by Github CLI (`gh`)
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run build.yml --ref ${{ env.PR_BRANCH }}


### PR DESCRIPTION
This allows cleaning up our workflows.

The manual trigger was there as using the default token to push commits [does not trigger other workflows](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) (and we want to trigger `build.yml`). 

The manual commit statuses were there as commit statuses don't get set when triggered manually (by workflow_dispatch).